### PR TITLE
 Add lobby, spectator, and bot functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,15 @@ Based on a game that once existed in our universe. No ads, no cost, no third-par
 
 Built with Node.js, Socket.io, and FabricJS.
 
+## Stats and Performance
+
+Client initial load weighs in at < 650KB, and utilizes heavy caching for all resources, so that subsequent views are < 50KB.
+Node server runs empty at < 20MB of RAM, with 11 threads.
+
+- Each subsequent/simultaneous match (mostly because of the running game log) adds < 2MB of memory usage, and is mostly reclaimed when the connection ends
+- Running game logic for three fully automated bot matches does not spike above 3% CPU utilization on a 2.2 GHz core i7 processor (thanks, Socket.io!)
+- Extrapolated theory: 100 simultaneous human matches can run with minimal disruption to the event loop (TODO: Test this)
+
 ## How to play
 
 [Short Rule Summary](http://www.vyseri.com/images/tripletriad2.png)
@@ -29,16 +38,18 @@ The game, its rules, characters, and artwork are all copyrighted by Square Enix.
 - Sound effects for playing and flipping cards, and winning and losing the match
 - Shuffle or Boogie music (remix by Simple Music), with subtle playing indication (notes bounce in time to the music)
 - Immediate rematch option given to both players
+- Basic AI
 
 #### TODO List:
 
+- IN-PROGRESS: Allow users to half-start a game (lobby), then send a code/URL to have their friend join them, jackbox-style
+  - After the second player has joined, anyone else will just be a spectator (tricky bit)
+  - Allow spectators to connect to matches in progress (replay from game log)
+  - List matches in progress on home screen
+- Allow player to choose to wait for a human or have a bot opponent
 - HALF DONE: Resize all of the elements in the canvas on page resize (especially for orientation changes on phones)
 - Perfectly centered game board and title positioning
 - Add board background art
-- Allow users to half-start a game (lobby), then send a code/URL to have their friend join them, jackbox-style
-  - Similarly, after the second player has joined, anyone else will just be a spectator (tricky bit)
-  - Allow spectators to connect to matches in progress (replay from game log)
-  - List matches in progress on home screen
 - Allow users to choose names (maybe from a selection of FF VIII characters, to avoid vulgarity)
 - Add 30-second countdown timer per turn + autoplay functionality (initial logic for AI bots, just play the first card found that can capture an opponent's card, or the most defensive card available)
 - Add keyboard/controller support
@@ -47,7 +58,6 @@ The game, its rules, characters, and artwork are all copyrighted by Square Enix.
 - Add all extended game rule options (Open, Chain, Plus)
 - Stress tester script, to see how many active games can run at a time, and limit games to that upper bound, to ensure a minimum performance level (https://stackoverflow.com/a/16426868/5334305)
 - See about adding to https://www.crazygames.com/c/io
-- Create AI bot node clients, and allow player to choose to wait for a human or have a bot opponent
 - Allow page refresh without quitting match
 - Add minimal analytics (number of players/matches/final score)
 - Add fun Final Fantasy VIII facts to push to clients while waiting for a game

--- a/README.md
+++ b/README.md
@@ -39,14 +39,14 @@ The game, its rules, characters, and artwork are all copyrighted by Square Enix.
 - Shuffle or Boogie music (remix by Simple Music), with subtle playing indication (notes bounce in time to the music)
 - Immediate rematch option given to both players
 - Basic AI
+- Allow users to half-start a game (lobby), then send a code/URL to have their friend join them, jackbox-style
+  - After the second player has joined, anyone else will be a spectator
+  - Allow spectators to connect to matches in progress (replay from game log)
+  - List matches in progress on home screen
+  - Play against bot opponent
 
 #### TODO List:
 
-- IN-PROGRESS: Allow users to half-start a game (lobby), then send a code/URL to have their friend join them, jackbox-style
-  - After the second player has joined, anyone else will just be a spectator (tricky bit)
-  - Allow spectators to connect to matches in progress (replay from game log)
-  - List matches in progress on home screen
-- Allow player to choose to wait for a human or have a bot opponent
 - HALF DONE: Resize all of the elements in the canvas on page resize (especially for orientation changes on phones)
 - Perfectly centered game board and title positioning
 - Add board background art

--- a/libs/ai.js
+++ b/libs/ai.js
@@ -14,8 +14,19 @@
 let cards = require("./cards");
 let debugMode = true;
 
-
 let ai = {
+	// The game manager needs access to the card list to generate matched decks, and the AI obviously needs access to the card stats to do analysis, so we load it here as the single source of truth
+	cardList: cards,
+
+	// Since we always need to indicate the card and the location, provide a standardized function for it
+	formatPlay: function (match, myIndex, cardIndex, location) {
+		return {
+			socket: match.players[myIndex].socket,
+			cardIndex: cardIndex,
+			location: location
+		}
+	},
+
 	// Prefix and log messages, as necessary
 	log: function (logString, match, myIndex) {
 		logString = ` - ${match.players[myIndex].color} AI: ${logString}`;
@@ -28,17 +39,12 @@ let ai = {
 		}
 	},
 
-	// Since we always need to indicate the card and the location, provide a standardized function for it
-	formatPlay: function (match, myIndex, cardIndex, location) {
-		return {
-			socket: match.players[myIndex].socket,
-			cardIndex: cardIndex,
-			location: location
-		}
-	},
-
 	// Primary logic
 	play: function (match, myIndex) {
+		if (typeof myIndex === 'object') {
+			myIndex = match.players.indexOf(myIndex);
+		}
+
 		// If I am playing the first card of the round, just play my lowest card in the center
 		let bestCardIndex = this.determineMinMaxCard(match, myIndex, 'best');
 		let worstCardIndex = this.determineMinMaxCard(match, myIndex, 'worst');
@@ -67,7 +73,7 @@ let ai = {
 			// Then use the lowest-ranked option (future: that is reasonably safe)
 			// for (let i = 0; i < boardAnalysis.attackableSpaces.length; i++) {
 			// 	for (let j = 0; j < match.players[myIndex].cards.length; j++) {
-			// 		if (match.players[myIndex].cards[j] !== undefined)
+			// 		if (match.players[myIndex].cards[j])
 			// 		let captures = playCard(match.players[myIndex].socket, match.players[myIndex].cards[j], boardAnalysis.attackableSpaces[i], 'preview');
 			// 		if (captures.length > 1) {
 			// 			potentialMoves.highValue.push({cardIndex: j, location: boardAnalysis.attackableSpaces[i]});

--- a/libs/game_manager.js
+++ b/libs/game_manager.js
@@ -1,16 +1,15 @@
 // This file handles all socket.io connections and manages the server-side game logic.
 
-let socketio = require("socket.io");
+let socketIO = require("socket.io");
 
-let cards = require("./cards");
 let AI = require("./ai");
 
 let debugMode = true;
 
 let players = [];
-let queue = [];
+let lobbies = [];
 let matches = [];
-let rematchRequests = [];
+let totalMatchesPlayed = 0;
 
 let timerDuration = 22;
 
@@ -30,18 +29,48 @@ let emptyBoard = [
 // DISABLE COUNTDOWN TIMERS, FOR NOW
 // updateGameTimers();
 
+const matchChecker = RegExp(/[ACDEFGHJKLMNPRTUWXY3679]{4}/);
+
 //////////  Socket.io  \\\\\\\\\\
 module.exports.listen = function (app) {
-	io = socketio.listen(app);
+	io = socketIO.listen(app);
+
 	io.on("connection", function (socket) {
+		console.log(`Player connected`);
 		players.push({
-			socket: socket,
-			deck: undefined
+			socket: socket
 		});
 
-		// BEGIN TESTING ONLY: IMMEDIATELY START GAME
-		enterQueue(socket);
-		// END TESTING ONLY
+		// Handle players/spectators requesting a specific match
+		let requestPieces = socket.handshake.headers.referer.split('/')
+		let potentialMatchId = requestPieces[requestPieces.length - 1]
+		let matchIdCheck = matchChecker.test(potentialMatchId);
+		if (matchIdCheck) {
+			let match = findMatchById(potentialMatchId);
+			if (!match) {
+				lobby = findMatchById(potentialMatchId, true);
+				// The match does not exist in any form--send event to redirect
+				if (!lobby) {
+					socket.emit("no match found");
+				} else {
+					console.log(`Player joined lobby ${potentialMatchId}`);
+					createMatch([lobby.lobbyLeader, findPlayerBySocketId(socket.id)], lobby);
+				}
+			} else {
+				console.log(`Spectator joined match ${potentialMatchId}`);
+				match.spectators.push({socket: socket});
+				// Setting spectator: true is critical for spectators to work
+				socket.emit("enter match", Object.assign({}, { spectator: true, roundStrength: match.roundStrength, scoreboard: match.scoreboard, runningScore: match.runningScore, playerColor: 'blue', opponentColor: 'red', log: match.log }));
+				socket.join(potentialMatchId);
+			}
+		} else {
+
+			// BEGIN TESTING ONLY: IMMEDIATELY START GAME
+			// enterQueue(socket);
+			// END TESTING ONLY
+		}
+
+		// TODO: Determine what triggers on a page refresh and add spectator cleanup to the list of things to do
 
 		socket.on("reconnect", function () {
 			console.log("TODO: IMPLEMENT RECONNECT SO THAT A PAGE REFRESH DOES NOT MEAN A FORFEIT");
@@ -53,12 +82,8 @@ module.exports.listen = function (app) {
 			playerDisconnectedFromMatch(socket);
 		});
 
-		socket.on("enter queue", function () {
-			enterQueue(socket);
-		});
-
-		socket.on("leave queue", function () {
-			leaveQueue(socket);
+		socket.on("create lobby", function (detail) {
+			startLobby(socket, detail);
 		});
 
 		socket.on("play card", function (index, location) {
@@ -67,6 +92,10 @@ module.exports.listen = function (app) {
 
 		socket.on("leave match", function () {
 			leaveMatch(socket);
+		});
+
+		socket.on("request game list", function () {
+			updateMatchStatistics(socket);
 		});
 
 		socket.on("request rematch", function () {
@@ -117,56 +146,88 @@ function log (logString, match) {
 
 // Lobby/Queue Management
 
-function enterQueue (socket) {
-	var player = findPlayerById(socket.id);
-	if (queue.indexOf(player) === -1) {
-		queue.push(player);
-		socket.emit("queue entered");
-		if (queue.length >= 2) {
-			createMatch([queue.shift(), queue.shift()]);
-		}
-	}
-}
-
-function leaveQueue (socket) {
-	var player = findPlayerById(socket.id);
-	var index = queue.indexOf(player);
-	if (index > -1) {
-		queue.splice(index, 1);
-	}
-	socket.emit("queue left");
+// TODO: Handle different configuration options from `gameConfig`
+function startLobby (socket, gameConfig) {
+	var player = findPlayerBySocketId(socket.id);
+	createLobby(player, gameConfig);
+	// TODO: Set up additional bits, and move pieces from createMatch(), as necessary
 }
 
 // Match Management
 
 function createId (idLength = 4) {
 	var id = "";
-	var charset = "ACDEFGHJKLMNPRTUWXY34679"; // Only use easy-to-read options
+	var charset = "ACDEFGHJKLMNPRTUWXY3679"; // Only use easy-to-read options
 	for (var i = 0; i < idLength; i++) {
 		id += charset.charAt(Math.floor(Math.random() * charset.length));
 	}
+
 	// Check against the unlikely event that the generated id already exists, and create an alternate ID
+	if (idLength === 2) {
+		for (var i = 0; i < players.length; i++) {
+			if (players[i].bot === true && players[i].socket === id) {
+				return createId(idLength);
+			}
+		}
+		return id;
+	}
+
+	for (var i = 0; i < lobbies.length; i++) {
+		if (lobbies[i].matchId === id) {
+			return createId(idLength);
+		}
+	}
 	for (var i = 0; i < matches.length; i++) {
-		if (matches[i].id === id) {
+		if (matches[i].matchId === id) {
 			return createId(idLength);
 		}
 	}
 	return id;
 }
 
-function createMatch (participants) {
+function createLobby (lobbyLeader, gameConfig) {
 	let id = createId();
-	let startingPlayer = (Math.floor(Math.random() * 2) === 0)? 0 : 1;
+	let lobby = {
+		lobbyLeader: lobbyLeader,
+		matchId: id,
+		private: gameConfig.private,
+		rules: gameConfig.rules,
+		solo: gameConfig.solo
+	};
+
+	if (gameConfig.solo) {
+		let botId = `BOT-${createId(2)}`;
+		players.push({
+			bot: true,
+			socket: {
+				emit: function () {},
+				join: function () {},
+				id: botId
+			}
+		});
+		console.log(`Bot ${botId} created for match: ${id}`);
+		createMatch([lobbyLeader, findPlayerBySocketId(botId)], lobby);
+	} else {
+		lobbies.push(lobby);
+		lobbyLeader.socket.emit("lobby created", id);
+
+		updateMatchStatistics();
+	}
+}
+
+function createMatch (participants, lobby) {
+	let startingPlayerIndex = (Math.floor(Math.random() * 2) === 0)? 0 : 1;
 	let match = {
 		matchCount: 0,
-		matchId: id,
+		matchId: lobby.matchId,
 		players: [],
-		rules: "BASIC",
+		rules: lobby.rules,
 		runningScore: {
 			red: 0,
 			blue: 0
 		},
-		spectators: [], // TODO: Implement
+		solo: lobby.solo,
+		spectators: [],
 		timerActive: false,
 		timer: timerDuration
 	};
@@ -175,8 +236,9 @@ function createMatch (participants) {
 
 	for (var i = 0; i < participants.length; i++) {
 		var playerObject = {
-			activePlayer: (i === startingPlayer),
-			color: (i === startingPlayer)? 'red' : 'blue',
+			activePlayer: (i === startingPlayerIndex),
+			bot: participants[i].bot || false,
+			color: (i === startingPlayerIndex)? 'red' : 'blue',
 			socket: participants[i].socket,
 			deck: generateDeck(), // BUG: We should be able to do this in startNewRound(), but the events on the client clear the board unnecessarily
 			cards: []
@@ -184,12 +246,17 @@ function createMatch (participants) {
 		match.players.push(playerObject);
 		// TODO: CLEANUP: Just have a single state object that contains all of the round and match information to send to the clients, or a function that assembles the data on-the-fly, to keep duplication down
 		participants[i].socket.emit("enter match", Object.assign({}, { roundStrength: match.roundStrength, scoreboard: match.scoreboard, runningScore: match.runningScore, playerColor: playerObject.color, opponentColor: (playerObject.color === 'red') ? 'blue' : 'red' }));
-		participants[i].socket.join(id);
+
+		participants[i].socket.join(match.matchId);
 	}
 
 	// io.to(id).emit("enter match"); // This was the old way of starting the match
 	matches.push(match);
 
+	var index = lobbies.indexOf(lobby);
+	if (index > -1) {
+		lobbies.splice(index, 1);
+	}
 
 	// HARD-CODED REMATCH TESTING
 	// match.matchCount = 3;
@@ -209,16 +276,30 @@ function createMatch (participants) {
 	// 	endMatch(match);
 	// }, 2000);
 
+	console.log(`CREATE MATCH: ${match.matchId}`);
+
+	match.started = true;
 	startNewRound(match);
 	match.timerActive = true;
 }
 
 function endMatch (match) {
+	totalMatchesPlayed++;
 	console.log('END MATCH');
 	io.to(match.matchId).emit("end match", {scoreboard: match.scoreboard, log: match.log, runningScore: match.runningScore});
 	match.isOver = true;
 
-	// console.log(match);
+	updateMatchStatistics();
+}
+
+function findMatchById (matchId, checkLobby) {
+	let arrayToCheck = (checkLobby) ? lobbies: matches;
+	for (var i = 0; i < arrayToCheck.length; i++) {
+		if (arrayToCheck[i].matchId === matchId) {
+			return arrayToCheck[i];
+		}
+	}
+	return false;
 }
 
 function findMatchBySocketId (socketId) {
@@ -232,7 +313,7 @@ function findMatchBySocketId (socketId) {
 	return false;
 }
 
-function findPlayerById (socketId) {
+function findPlayerBySocketId (socketId) {
 	for (var i = 0; i < players.length; i++) {
 		if (players[i].socket.id === socketId) {
 			return players[i];
@@ -255,13 +336,13 @@ function leaveMatch (socket) {
 }
 
 function playerDisconnectedFromMatch (socket) {
-	var player = findPlayerById(socket.id);
+	var player = findPlayerBySocketId(socket.id);
 	var index = players.indexOf(player);
 	if (index > -1) {
-		leaveQueue(socket);
 		leaveMatch(socket);
 		players.splice(index, 1);
 	}
+	// TODO: Remove any lobbies or matches the player is part of
 }
 
 // Reset the bits that need to be for each match
@@ -292,7 +373,7 @@ Object.assign(match, defaults)
 function rematchRequested (socket) {
 	var match = findMatchBySocketId(socket.id);
 	if (match) {
-		if (match.rematch && match.rematch !== socket.id) {
+		if ((match.rematch && match.rematch !== socket.id) || match.solo) {
 			setMatchDefaults(match, true);
 			io.to(match.matchId).emit("update score", {scoreboard: match.scoreboard, runningScore: match.runningScore});
 			startNewRound(match);
@@ -310,8 +391,39 @@ function removeMatch (match) {
 	updateMatchStatistics();
 }
 
-function updateMatchStatistics () {
-	// active games, open lobbies, total number of games, ever, and push to anyone in lobby
+// TODO: Build in throttling, so that the actual game is not bogged down by extra notifications
+function updateMatchStatistics (playerSocket) {
+	let stats = {
+		lobbies: [],
+		matches: [],
+		totalMatchesPlayed: totalMatchesPlayed,
+		totalPlayers: players.length, // includes players and spectators
+		totalBotsInGame: 0
+	}
+
+	for (let i = 0; i < lobbies.length; i++) {
+		let match = lobbies[i];
+
+		if (!match.private) {
+			stats.lobbies.push({id: match.matchId});
+		}
+	}
+
+	for (let i = 0; i < matches.length; i++) {
+		let match = matches[i];
+
+		if (match.started) {
+			stats.matches.push({id: match.matchId, spectatorCount: match.spectators.length, matchCount: match.matchCount, runningScore: match.runningScore});
+		}
+	}
+
+	if (playerSocket) {
+		playerSocket.emit("update stats", stats);
+	} else {
+		for (let z = 0; z < players.length; z++) {
+			players[z].socket.emit("update stats", stats);
+		}
+	}
 }
 
 // Round Scoring & Management
@@ -379,7 +491,7 @@ function attack (match, coords, attackingDirection, replay) {
 				match.roundStrength[attackingLocation.color]++;
 				match.roundStrength[defendingLocation.color]--;
 				defendingLocation.color = attackingLocation.color;
-				log(` - ${attackingLocation.color} capture: ${attackingDirection}: ${defendingLocation.card.name}`, match);
+				log(`${attackingLocation.color}:capture:${defendingLocationString}:${defendingLocation.card.name} (${attackingDirection})`, match);
 				io.to(match.matchId).emit("card flipped", {location: defendingLocationString, matchDetail: { roundStrength: match.roundStrength}});
 			}
 		// TODO: equal values can flip on the initial placement, and then flipped cards can "combo", flipping additional cards if they are more powerful.
@@ -448,11 +560,12 @@ function processRound (match) {
  * @returns {undefined} - Modifies match data directly, and EMITS hand to player.
  */
 function startNewRound (match, tiebreakerRound) {
+	updateMatchStatistics();
 	if (tiebreakerRound) {
-		log(`Round ${match.roundNumber} Tiebreaker`, match);
+		log(`Begin Round ${match.roundNumber} Tiebreaker ${match.matchId}`, match);
 	} else {
 		match.roundNumber++;
-		log(`Begin Round ${match.roundNumber}`, match);
+		log(`Begin Round ${match.roundNumber} ${match.matchId}`, match);
 	}
 	match.board = JSON.parse(JSON.stringify(emptyBoard));
 	match.roundStrength = {red: 5, blue: 5}
@@ -478,6 +591,11 @@ function startNewRound (match, tiebreakerRound) {
 		}
 		dealHand(player);
 		player.socket.emit("draw hand", player.cards);
+	}
+
+	for (var i = 0; i < match.spectators.length; i++) {
+		let spectator = match.spectators[i];
+		spectator.socket.emit("draw hand", true);
 	}
 
 	toggleActivePlayer(match);
@@ -533,7 +651,11 @@ function toggleActivePlayer (match) {
 	for (var i = 0; i < match.players.length; i++) {
 		let player = match.players[i];
 		player.activePlayer = !player.activePlayer;
-		player.socket.emit("enable cards", player.activePlayer);
+		player.socket.emit("enable hand", player.activePlayer);
+
+		if (player.bot && player.activePlayer) {
+			playAICard(AI.play(match, player));
+		}
 	}
 }
 
@@ -561,11 +683,11 @@ function generateDeck (distribution) {
 
 	for (let [tier, count] of Object.entries(distribution || balancedDeckDistribution)) {
 		for (var i = 0; i < count; i++) {
-			var randomCardIndex = Math.floor(Math.random() * (cards[tier].length));
+			var randomCardIndex = Math.floor(Math.random() * (AI.cardList[tier].length));
 			// console.log(tier, randomCardIndex, (cards[tier][randomCardIndex]) ? cards[tier][randomCardIndex].name : 'ERROR');
 			// TODO: Generate random card IDs to discourage cheating
 			// TODO: Try to avoid duplicates between players
-			deck.push(cards[tier][randomCardIndex]);
+			deck.push(AI.cardList[tier][randomCardIndex]);
 		}
 	}
 
@@ -622,23 +744,34 @@ function playCard (socket, cardIndex, location, replay) {
 					boardLocation.card = card;
 					boardLocation.color = player.color;
 
-					log(`${player.color}: ${location}: ${card.name}`, match);
+					log(`${player.color}:play:${location}:${cardIndex}:${card.id}:${card.name}`, match);
+
 					opponent.socket.emit("card played", {cardIndexInHand: cardIndex, location: location, color: opponent.color, cardImageId: card.id});
 					if (replay) {
 						player.socket.emit("card played", {cardIndexInHand: cardIndex, location: location, color: player.color, cardImageId: card.id, mine: true});
 					}
+					for (var i = 0; i < match.spectators.length; i++) {
+						let spectator = match.spectators[i];
+						spectator.socket.emit("card played", {cardIndexInHand: cardIndex, location: location, color: player.color, cardImageId: card.id, spectator: (player.color === 'blue') ? true : false});
+					}
+
 					player.cards[cardIndex] = null;
-					// Only toggle the active player if a player still has cards. The active player switches at the start of each round
+
+					// Only toggle the active player if a player still has cards. The active player switches at the start of each round, in order to alternate fairly
 					for (let i = 0; i < player.cards.length; i++) {
 						if (player.cards[i]) {
-							toggleActivePlayer(match);
+							// We want calculateResult to happen before toggling the active player, but calculateResult *could* trigger a new round, which would give the players new cards, so, we're using a timeout, because using an intermediary value didn't work...however, this also makes things awkward when attempting to run a pure bot match...
+							setTimeout(() => {
+								toggleActivePlayer(match);
+							}, 0);
 							break;
 						}
 					}
 
 					calculateResult(match, coords, replay);
+
 				} else {
-					console.log(`INVALID PLAY (cardIndex: ${cardIndex})`);
+					console.log(`INVALID PLAY: (card already played: ${cardIndex})`);
 					console.log(player.cards);
 				}
 			}

--- a/public/index.html
+++ b/public/index.html
@@ -37,7 +37,7 @@ Welcome, adventurer!
 				z-index: 0;
 			}
 
-			.games-list {
+			.overlay {
 				background-color: rgba(221, 170, 68, 0.75);
 				bottom: 0;
 				display: none;
@@ -47,7 +47,12 @@ Welcome, adventurer!
 				top: 0;
 			}
 
-			[in-lobby] .games-list {
+			[lurking] .overlay,
+			[inlobby] .overlay {
+				display: block;
+			}
+
+			.games-list {
 				display: flex;
 			}
 
@@ -66,7 +71,7 @@ Welcome, adventurer!
 
 			.lobby-list li,
 			.game-list li {
-				font-size: larger;
+
 				list-style: none;
 				margin: 1px 0;
 				position: relative;
@@ -83,12 +88,40 @@ Welcome, adventurer!
 				left: 0;
 				pointer-events: none;
 				position: absolute;
-				width: 1rem;
+				width: 1.15rem;
+			}
+
+			.billboard {
+				align-items: center;
+				background-color: rgba(221, 170, 68, 0.5);
+				bottom: 0;
+				display: none;
+				flex-direction: column;
+				left: 0;
+				padding: 20%;
+				position: absolute;
+				right: 0;
+				text-align: center;
+				top: 0;
+			}
+
+			[inlobby] .billboard {
+				display: flex;
+			}
+
+			.game-link {
+				margin: 0;
+				padding: 20px;
+			}
+
+			.game-link,
+			a {
+				font-family: "Lucida Console", Monaco, monospace;
+				font-size: larger;
 			}
 
 			.lobby-list a,
 			.game-list a {
-				font-family: "Lucida Console", Monaco, monospace;
 				padding-left: 1.5rem;
 			}
 
@@ -130,6 +163,10 @@ Welcome, adventurer!
 				display: flex;
 				position: absolute;
 				width: 100%;
+			}
+
+			[inlobby] .match-buttons {
+				display: none;
 			}
 
 			.create-public-match,
@@ -185,25 +222,34 @@ Welcome, adventurer!
 		</style>
 	</head>
 
-	<body in-lobby>
+	<body lurking>
 		<div id="content">
 			<canvas id="fabric-canvas" class="center-block" width="0" height="0"></canvas>
 
-			<div class="games-list">
-				<section class="list-container">
-					<h3>Lobbies (click to join):</h3>
-					<ul class="lobby-list">
-					</ul>
-				</section>
-				<section class="list-container">
-					<h3>Active Games (click to spectate):</h3>
-					<ul class="game-list">
-					</ul>
-				</section>
-				<div class="match-buttons">
-					<button class="create-public-match" onclick="createMatch()">Create Public Match</button>
-					<button class="create-bot-match" onclick="createMatch(true, true)">Practice against Bot</button>
-					<button class="create-private-match" onclick="createMatch(true)">Create Private Match</button>
+			<div class="overlay">
+				<div class="games-list">
+					<section class="list-container">
+						<h3>Lobbies (click to join):</h3>
+						<ul class="lobby-list">
+						</ul>
+					</section>
+					<section class="list-container">
+						<h3>Active Games (click to spectate):</h3>
+						<ul class="game-list">
+						</ul>
+					</section>
+					<div class="match-buttons">
+						<button class="create-public-match" onclick="createMatch()">Create Public Match</button>
+						<button class="create-bot-match" onclick="createMatch(true, true)">Practice against Bot</button>
+						<button class="create-private-match" onclick="createMatch(true)">Create Private Match</button>
+					</div>
+				</div>
+
+				<div class="billboard">
+					<h2>Send this link to a friend:</h2>
+					<p class="game-link"></p>
+					<p class="subtext">After the first person has joined, the match will begin,<br/>and anyone else using the link will be able to spectate.</p>
+					<p>OR, <button onclick="cancelMatch()">go back</button> to lobbies</p>
 				</div>
 			</div>
 
@@ -315,6 +361,10 @@ Welcome, adventurer!
 
 			function showHowToPlay () {
 				document.querySelector('#how-to-play').removeAttribute('hidden');
+			}
+
+			function cancelMatch () {
+				document.dispatchEvent(new CustomEvent('event:cancel-lobby'));
 			}
 
 			function createMatch (private, bot) {

--- a/public/index.html
+++ b/public/index.html
@@ -14,6 +14,10 @@ Welcome, adventurer!
 				background-color: #210;
 			}
 
+			#content {
+				position: relative;
+			}
+
 			.canvas-container {
 				margin: 0 auto;
 				transition: opacity 0.2s;
@@ -31,6 +35,72 @@ Welcome, adventurer!
 				background-size: contain;
 				border: 3px double #000;
 				z-index: 0;
+			}
+
+			.games-list {
+				background-color: rgba(221, 170, 68, 0.75);
+				bottom: 0;
+				display: none;
+				left: 5vw;
+				position: absolute;
+				right: 5vw;
+				top: 0;
+			}
+
+			[in-lobby] .games-list {
+				display: flex;
+			}
+
+			.list-container {
+				display: flex;
+    		flex-direction: column;
+				width: 50%;
+			}
+
+			.lobby-list,
+			.game-list {
+				margin: 0 10px 54px 10px;
+				overflow: scroll;
+				padding: 0;
+			}
+
+			.lobby-list li,
+			.game-list li {
+				font-size: larger;
+				list-style: none;
+				margin: 1px 0;
+				position: relative;
+			}
+
+			.lobby-list li::before,
+			.game-list li::before {
+				background-image: url('/images/cards/back.png');
+				background-size: contain;
+				border-radius: 3px;
+				content: '';
+				display: inline-block;
+				height: 100%;
+				left: 0;
+				pointer-events: none;
+				position: absolute;
+				width: 1rem;
+			}
+
+			.lobby-list a,
+			.game-list a {
+				font-family: "Lucida Console", Monaco, monospace;
+				padding-left: 1.5rem;
+			}
+
+			a,
+			a:active,
+			a:visited {
+				color: #210;
+				text-decoration: none;
+			}
+
+			a:hover {
+				text-decoration: underline;
 			}
 
 			[disabled] {
@@ -53,6 +123,23 @@ Welcome, adventurer!
 				min-width: 1rem;
 				padding: 5px;
 				position: absolute;
+			}
+
+			.match-buttons {
+				bottom: 0;
+				display: flex;
+				position: absolute;
+				width: 100%;
+			}
+
+			.create-public-match,
+			.create-private-match,
+			.create-bot-match {
+				position: relative;
+			}
+
+			.create-bot-match {
+				margin: 0 auto;
 			}
 
 			.help-button {
@@ -98,47 +185,58 @@ Welcome, adventurer!
 		</style>
 	</head>
 
-	<body>
+	<body in-lobby>
 		<div id="content">
 			<canvas id="fabric-canvas" class="center-block" width="0" height="0"></canvas>
 
-			<!-- <section>
-				<h3>TODO: Active Games</h3>
-				<ul>
-					<li><a href="/watch/"> (round <span class="round-number">3</span>)</a></li>
-				</ul>
-			</section> -->
-
-			<button class="help-button" type="button" title="How To Play Triple Triad" onclick="showHowToPlay()">♕?</button>
-			<button class="music-button" type="button" title="Toggle Music" onclick="toggleMusic(this)"><span class="note-1 bounce">♪</span>&nbsp;<span class="note-2 bounce">♬</span></button>
-			<div id="how-to-play" class="fullscreen" onclick="hideHowToPlay()" hidden>
-				<h1>How To Play Triple Triad</h1>
-				<p>
-					Triple Triad is a two-player game played on a three-by-three (3x3) square grid. Each card has four numbers (known as ranks) placed in top left corner; each number corresponds to one of the four sides of the card. The ranks range from one to ten, the letter A representing ten. Colored cards belong to the player and monochromatic cards belong to the opponent.
-				</p><p>
-					In each round, a player is dealt five cards from their deck. The first player is randomly chosen for the first round, and then switches between players for each subsequent round. Each player then alternates playing a single card onto any unoccupied space on the board.
-				</p>
-				<h2>Winning</h2>
-				<p>
-					To win a round, a majority of the total ten cards played (including the one card that is not placed on the board) must be controlled by a player. To capture an opponent's card, the active player places a card adjacent to it. If the rank touching the opponent's card is higher, the opponent's card will be captured and flipped to the player's color. The player who goes second will have a card remaining in their hand and that card will count towards their ending score.
-				</p><p>
-					A draw occurs if at the end of the round the player and the opponent control an equal number of cards. The round then proceeds into a sudden death tiebreaker scenario where each player receives the cards they currently control as a new hand, and the round is repeated until a winner is decided.
-				</p><p>
-					Matches are played best out of three rounds.
-				<h2>Rules</h2>
-				<h3>Random (always enabled)</h3>
-				<p>
-					In order to better balance gameplay, a ten-card deck, with one card coming from each of the ten ranks of cards, is randomly generated for each player at the beginning of each match. Players then draw two five-card hands for the first two rounds of the match. If a match winner is still undecided after two rounds, a final high-power hand is randomly generated with one card from each of only the top five tiers.
-				</p>
-				<h3>Basic</h3>
-				</p><p>
-					The default mode of gameplay. An opponent's card can only be captured by a player's card being placed orthogonally adjacent to it that is more powerful than the opponent's card in the shared direction.
-				</p>
-				<h3>Unimplemented</h3>
-				<p>
-					The following have yet to be implemented: Same, Same Wall, Plus, Combo, and Elemental.
-				</p>
+			<div class="games-list">
+				<section class="list-container">
+					<h3>Lobbies (click to join):</h3>
+					<ul class="lobby-list">
+					</ul>
+				</section>
+				<section class="list-container">
+					<h3>Active Games (click to spectate):</h3>
+					<ul class="game-list">
+					</ul>
+				</section>
+				<div class="match-buttons">
+					<button class="create-public-match" onclick="createMatch()">Create Public Match</button>
+					<button class="create-bot-match" onclick="createMatch(true, true)">Practice against Bot</button>
+					<button class="create-private-match" onclick="createMatch(true)">Create Private Match</button>
+				</div>
 			</div>
+
+		</div>
+		<button class="help-button" type="button" title="How To Play Triple Triad" onclick="showHowToPlay()">♕?</button>
+		<button class="music-button" type="button" title="Toggle Music" onclick="toggleMusic(this)"><span class="note-1 bounce">♪</span>&nbsp;<span class="note-2 bounce">♬</span></button>
+		<div id="how-to-play" class="fullscreen" onclick="hideHowToPlay()" hidden>
+			<h1>How To Play Triple Triad</h1>
+			<p>
+				Triple Triad is a two-player game played on a three-by-three (3x3) square grid. Each card has four numbers (known as ranks) placed in top left corner; each number corresponds to one of the four sides of the card. The ranks range from one to ten, the letter A representing ten. Colored cards belong to the player and monochromatic cards belong to the opponent.
+			</p><p>
+				In each round, a player is dealt five cards from their deck. The first player is randomly chosen for the first round, and then switches between players for each subsequent round. Each player then alternates playing a single card onto any unoccupied space on the board.
+			</p>
+			<h2>Winning</h2>
+			<p>
+				To win a round, a majority of the total ten cards played (including the one card that is not placed on the board) must be controlled by a player. To capture an opponent's card, the active player places a card adjacent to it. If the rank touching the opponent's card is higher, the opponent's card will be captured and flipped to the player's color. The player who goes second will have a card remaining in their hand and that card will count towards their ending score.
+			</p><p>
+				A draw occurs if at the end of the round the player and the opponent control an equal number of cards. The round then proceeds into a sudden death tiebreaker scenario where each player receives the cards they currently control as a new hand, and the round is repeated until a winner is decided.
+			</p><p>
+				Matches are played best out of three rounds.
+			<h2>Rules</h2>
+			<h3>Random (always enabled)</h3>
+			<p>
+				In order to better balance gameplay, a ten-card deck, with one card coming from each of the ten ranks of cards, is randomly generated for each player at the beginning of each match. Players then draw two five-card hands for the first two rounds of the match. If a match winner is still undecided after two rounds, a final high-power hand is randomly generated with one card from each of only the top five tiers.
+			</p>
+			<h3>Basic</h3>
+			</p><p>
+				The default mode of gameplay. An opponent's card can only be captured by a player's card being placed orthogonally adjacent to it that is more powerful than the opponent's card in the shared direction.
+			</p>
+			<h3>Unimplemented</h3>
+			<p>
+				The following have yet to be implemented: Same, Same Wall, Plus, Combo, and Elemental.
+			</p>
 		</div>
 
 		<script src="/socket.io/socket.io.js"></script>
@@ -217,6 +315,14 @@ Welcome, adventurer!
 
 			function showHowToPlay () {
 				document.querySelector('#how-to-play').removeAttribute('hidden');
+			}
+
+			function createMatch (private, bot) {
+				document.dispatchEvent(new CustomEvent('event:create-lobby', { detail: {
+					private: (private) ? true : false,
+					rules: "BASIC",
+					solo: (bot) ? true : false,
+				}}));
 			}
 
 			// Clicks will fall through all the way to the content wrapper, if the canvas is disabled

--- a/public/javascripts/canvas.js
+++ b/public/javascripts/canvas.js
@@ -116,21 +116,6 @@ let playerCards = [];
 let labels = [];
 let zoom = 1;
 
-// PROBABLY REMOVE THIS SPECIAL TREATMENT, AS IT SEEMS UNNECESSARY
-let tierColorMap = [
-	'', // There is no tier 0
-	'#24b',
-	'#24b',
-	'#24b',
-	'#24b',
-	'#24b',
-	'#94b',
-	'#94b',
-	'#94b',
-	'#ccc',
-	'#eb0',
-];
-
 init();
 
 window.addEventListener("resize", handleResize, false);
@@ -215,7 +200,7 @@ function locationToGridIndex (location) {
 
 // Given a hand card index and a location, move the given card, also revealing it, if a cardImageId is passed (always, for spectators or opponent's cards)
 function moveCard (moveDetail) {
-	let card = (moveDetail.mine) ?
+	let card = (moveDetail.mine || moveDetail.spectator) ?
 		playerCards.splice(moveDetail.cardIndexInHand, 1, undefined)[0] :
 		opponentCards.splice(moveDetail.cardIndexInHand, 1, undefined)[0];
 
@@ -232,7 +217,7 @@ function moveCard (moveDetail) {
 			duration: 500,
 			easing: fabric.util.ease.easeInOutExpo,
 			onChange: canvas.renderAll.bind(canvas),
-			onComplete: (moveDetail.mine) ? undefined: fetchCardFace.bind(card)
+			onComplete: (moveDetail.mine && !moveDetail.spectator) ? undefined: fetchCardFace.bind(card)
 		});
 	}
 }
@@ -266,14 +251,19 @@ function flipCard (cardToFlip) {
 		cardToFlip = gridCards[locationToGridIndex(cardToFlip)];
 	}
 
-	if (cardToFlip.color) {
-		cardToFlip.color = (cardToFlip.color === 'red') ? 'blue' : 'red';
+	if (cardToFlip.mine) {
+		// Catch the flip event correctly for spectators, and then remove the short-circuit
+		delete cardToFlip.mine;
+		cardToFlip.color = 'blue'; // When spectating, assume the player is blue
 	} else {
-		cardToFlip.color = (playerColor === 'red') ? 'blue' : 'red';
+		if (cardToFlip.color) {
+			cardToFlip.color = (cardToFlip.color === 'red') ? 'blue' : 'red';
+		} else {
+			cardToFlip.color = (playerColor === 'red') ? 'blue' : 'red';
+		}
 	}
 
 	let imageToFilter = (cardToFlip._objects && (cardToFlip._objects[1] || cardToFlip._objects[0]));
-
 	if (cardToFlip.color === playerColor) {
 		imageToFilter.applyFilters([]); // Cheap way to clear filters, since we don't know if any filters are currently being applied
 	} else {
@@ -327,6 +317,9 @@ function renderHand (cards, isOpponent) {
 	if (!cards) {
 		cards = [{}, {}, {}, {}, {}];
 		isOpponent = true;
+	} else if (cards === true) {
+		cards = [{}, {}, {}, {}, {}];
+		isOpponent = false;
 	}
 	for (let i = 0; i < cards.length; i++) {
 		renderCard(cards[i], i, isOpponent);
@@ -375,8 +368,10 @@ function renderCard (card, slot, isOpponent) {
 
 	if (!card) {return console.log(`ERROR rendering card[${slot}] for ${(isOpponent) ? 'opponent' : 'player'}`);}
 
+	let cardURL = (isOpponent || !card.id) ? `images/cards/back.png` : `images/cards/${card.id}.png`;
+
 	if (isOpponent && !card.id) {
-		fabric.Image.fromURL(`images/cards/back.png`, (img) => {
+		fabric.Image.fromURL(cardURL, (img) => {
 			img = img.scaleToWidth(cardWidth);
 			// In theory, we could invert the opponent's cards
 			// img.filters.push(new fabric.Image.filters.Invert());
@@ -398,12 +393,12 @@ function renderCard (card, slot, isOpponent) {
 			canvas.renderAll();
 		});
 	} else {
-		fabric.Image.fromURL(`images/cards/${card.id}.png`, (img) => {
+		fabric.Image.fromURL(cardURL, (img) => {
 			img = img.scaleToWidth(cardWidth);
 			img.filters = [new fabric.Image.filters.Grayscale()]; // Add flipping filter to every card
 			cardGroup = new fabric.Group([ img ], Object.assign({
-				// backgroundColor: tierColorMap[card.tier] // AFTER CARDS HAVE TRANSPARENT BACKGROUNDS
-				borderColor: tierColorMap[card.tier],
+				borderColor: '#24b',
+				evented: (!card.id) ? false : true,
 				// originX: 'center',
 				// originY: 'center',
 				// left: cardWidth,
@@ -414,6 +409,8 @@ function renderCard (card, slot, isOpponent) {
 
 			// Add card data to be used with card placement eventing
 			cardGroup.cardIndex = slot;
+			cardGroup.color = (isOpponent) ? opponentColor : playerColor;
+			cardGroup.mine = spectator;
 
 			// console.log(`renderCard (player): ${slot}`);
 

--- a/public/javascripts/canvas.js
+++ b/public/javascripts/canvas.js
@@ -36,12 +36,6 @@ function init() {
 	let labelFont = '';
 
 	handleResize();
-
-	labels["play"] = new Label({x: 0.5, y: 0.9}, "Play!", 144, true, true, false, labelFont, enterQueue);
-	labels["searching"] = new Label({x: 0.5, y: 0.9}, "Searching   ", 144, false, false, false, labelFont);
-	labels["result"] = new Label({x: 0.5, y: 0.2}, "", 192, false, false, false, labelFont);
-	labels["waiting"] = new Label({x: 0.5, y: 0.9}, "Waiting   ", 128, false, false, false, labelFont);
-	labels["main menu"] = new Label({x: 0.5, y: 0.7}, "Main Menu", 128, false, false, false, labelFont, exitMatch);
 }
 
 //////////  Events  \\\\\\\\\\

--- a/public/javascripts/game_client.js
+++ b/public/javascripts/game_client.js
@@ -1,9 +1,11 @@
 // This file manages the games client's logic. It's here that Socket.io connections are handled and functions from canvas.js are used to manage the game's visual appearance.
 
-let ANIMATION_TIME = 800;
+let ANIMATION_TIME = 600;
+let animationTimeout;
 let socket = io();
 let canPlayCard = false;
 let debugMode = true;
+let inLobby = true;
 let log;
 let playerColor = "";
 let playerRoundStrength = 5;
@@ -13,55 +15,70 @@ let opponentColor = "";
 let opponentRoundStrength = 5;
 let opponentRoundScore = 0;
 let opponentRunningScore;
-let cardEventQueue = [];
+let spectator = false;
+let gameEventQueue = [];
 let matchWinner, matchEndReason, readyToEnd, timerInterval;
 
 //////////  Socket Events  \\\\\\\\\\
+socket.on("lobby created", function (gameId) {
+	console.log(`${document.location.href}gameId`);
+	// TODO: Put up a placard overtop of everything else, with the link to have friends join
+});
+
 socket.on("enter match", function (matchDetail) {
+	// TODO: Add matchId to match detail, so that players can copy a link for friends to spectate
+	inLobby = false;
+	document.body.removeAttribute('in-lobby');
 	enterMatch(matchDetail);
 });
 
+// TODO: If playing a tiebreaker round, animate the cards back, instead of immediately clearing the board--maybe use a different event
 socket.on("draw hand", function (cards) {
 	// If we are in replay mode, keep from starting a new round until the current round is complete
-	if (cardEventQueue.length === 0) {
+	if (gameEventQueue.length === 0) {
 		// TODO: Add a way of acknowledging the previous round before starting the next one
 		setTimeout(() => {
 			startRound(cards);
 		}, ANIMATION_TIME);
 	} else {
-		cardEventQueue.push({type: 'draw', cards: cards});
+		gameEventQueue.push({type: 'draw', cards: cards});
 	}
 });
 
 // moveDetail format: {cardIndexInHand: 0, location: '1,1', color: 'red', cardImageId: '104'}
 socket.on("card played", function (moveDetail) {
 	moveDetail.type = 'move';
-	cardEventQueue.push(moveDetail);
-	if (cardEventQueue.length === 1) {
-		cardEvent();
-	}
+	gameEventQueue.push(moveDetail);
+	gameEvent();
 });
 
 // flipDetail format: {location: '1,1'}
 socket.on("card flipped", function (flipDetail) {
 	flipDetail.type = 'flip';
-	cardEventQueue.push(flipDetail);
-	if (cardEventQueue.length === 1) {
-		cardEvent();
-	}
+	gameEventQueue.push(flipDetail);
+	gameEvent();
 });
 
 socket.on("update score", function (matchDetail) {
-	cardEventQueue.push({type: 'stoplight', matchDetail: matchDetail});
+	gameEventQueue.push({type: 'stoplight', matchDetail: matchDetail});
+	gameEvent();
 });
 
-socket.on("enable cards", function (activePlayer) {
-	if (cardEventQueue.length === 0) {
-		setTimeout(() => {
-			updateActivePlayer(activePlayer);
-		}, ANIMATION_TIME);
-	} else {
-		cardEventQueue.push({type: 'enable', active: activePlayer});
+// NOTE: This fires 4x immediately when watching bot games, due to the match completing in under a second
+socket.on("update stats", function (stats) {
+	if (inLobby) {
+		// console.log(`update stats: ${stats}`);
+		updateGameList('.lobby-list', stats.lobbies);
+		updateGameList('.game-list', stats.matches);
+
+		// TODO: Update server stats (player/game counts, etc.), as well
+	}
+});
+
+socket.on("enable hand", function (activePlayer) {
+	if (!spectator) {
+		gameEventQueue.push({type: 'enable', active: activePlayer});
+		gameEvent();
 	}
 });
 
@@ -74,8 +91,12 @@ socket.on("replay match", function (matchDetail) {
 });
 
 socket.on("end match", function (matchDetail) {
-	cardEventQueue.push({type: 'end', matchDetail: matchDetail});
-	cardEvent(); // MAYBE?
+	gameEventQueue.push({type: 'end', matchDetail: matchDetail});
+});
+
+socket.on("no match found", function () {
+	console.log(`${window.location.pathname} match not found...redirecting...`);
+	window.location.replace("/");
 });
 
 socket.on("no rematch", function () {
@@ -84,9 +105,14 @@ socket.on("no rematch", function () {
 	}
 });
 
+// Initialize the game client
+
 // Catch the canvas play-card and rematch events, and send them on to Socket.io
+document.addEventListener('event:create-lobby', createMatch);
 document.addEventListener('event:play-card', playCard);
 document.addEventListener('event:rematch', rematch);
+
+socket.emit("request game list");
 
 //////////  Functions  \\\\\\\\\\
 function enterQueue () {
@@ -99,12 +125,16 @@ function enterQueue () {
 
 function enterMatch (matchDetail) {
 	// debugMode && console.log(`enterMatch`, matchDetail);
+	spectator = matchDetail.spectator;
 
 	playerColor = matchDetail.playerColor;
 	opponentColor = matchDetail.opponentColor;
-	playerRoundStrength = matchDetail.roundStrength[playerColor];
-	opponentRoundStrength = matchDetail.roundStrength[opponentColor];
-	cardEventQueue = [];
+	gameEventQueue = [];
+
+	// If the spectated game is already in-progress, parse out the events from the log and replay them
+	if (matchDetail.log && matchDetail.log.length) {
+		generateReplayFromLog(matchDetail);
+	}
 
 	updateScores(matchDetail);
 
@@ -118,6 +148,11 @@ function enterMatch (matchDetail) {
 	// displayCardSlots = true;
 }
 
+function createMatch (evt) {
+	debugMode && console.log("event:create-lobby", evt.detail);
+	socket.emit("create lobby", evt.detail);
+}
+
 function rematch (evt) {
 	debugMode && console.log("event:rematch", evt.detail);
 
@@ -126,68 +161,123 @@ function rematch (evt) {
 		socket.emit("request rematch");
 	} else {
 		socket.emit("leave match");
+		// TODO: Set state/show button to return to lobby
 	}
 }
 
 function playCard (evt) {
-	debugMode && console.log("event:play-card", evt.detail);
+	if (!spectator) {
+		debugMode && console.log("event:play-card", evt.detail);
 
-	socket.emit("play card", evt.detail.cardIndex, evt.detail.location);
-}
-
-// TODO: FIGURE: A single card event queue works, for now, assuming that events do not come out of order.
-// TODO: BUG: For extended matches, animation time appears to eventually drop to 0, maybe because there are extra cardEvent() calls left over.
-function cardEvent () {
-	if (isRenderComplete() && cardEventQueue.length) {
-		cardEventDetail = cardEventQueue.shift();
-		switch (cardEventDetail.type) {
-			case 'move':
-				debugMode && console.log(`play card:${cardEventDetail.location}, ${cardEventDetail.cardImageId} ${(cardEventDetail.mine) ? '(mine)' : ''}`);
-				moveCard(cardEventDetail);
-				break;
-			case 'flip':
-				// If there are multiple flips cached from the last play, grab them all to play simultaneously
-				debugMode && console.log(`flip card: ${cardEventDetail.location}`);
-				flipCard(cardEventDetail.location);
-				while (nextEventType('flip')) {
-					nextCardEventDetail = cardEventQueue.shift();
-					debugMode && console.log(`flip card: ${nextCardEventDetail.location}`);
-					flipCard(nextCardEventDetail.location);
-				}
-				updatePlayerStrengthValues(cardEventDetail.matchDetail);
-				break;
-			case 'draw':
-				debugMode && console.log(`io: draw hand --> canvas.startRound()`);
-				// TODO: Add a way of acknowledging the previous round before starting the next one
-				startRound(cardEventDetail.cards);
-				break;
-			case 'stoplight':
-				debugMode && console.log(`canvas.renderScoreStoplight() ${JSON.stringify(cardEventDetail.matchDetail.scoreboard)}`);
-				updateScores(cardEventDetail.matchDetail);
-				break;
-			case 'enable':
-				debugMode && console.log(`enable hand: ${cardEventDetail.active}`);
-				updateActivePlayer(cardEventDetail.active);
-				break;
-			case 'end':
-				debugMode && console.log(`endMatch`);
-				endMatch(cardEventDetail.matchDetail);
-				break;
-			default:
-				break;
-		}
-		setTimeout(() => {
-			cardEvent();
-		}, ANIMATION_TIME);
-	} else {
-		setTimeout(() => {
-			cardEvent();
-		}, ANIMATION_TIME);
+		socket.emit("play card", evt.detail.cardIndex, evt.detail.location);
 	}
 }
 
+// TODO: FIGURE: A single game event queue works, for now, assuming that events do not come out of order.
+// TODO: BUG: For extended matches, animation time appears to eventually drop to 0, because there are extra gameEvent() calls left over.
+function gameEvent () {
+	if (isRenderComplete()) {
+		if (gameEventQueue.length) {
+			if (animationTimeout) {
+				window.clearTimeout(animationTimeout);
+			}
+			animationTimeout = setTimeout(() => {
+				eventDetail = gameEventQueue.shift();
+				switch (eventDetail.type) {
+					case 'move':
+						debugMode && console.log(`play card:${eventDetail.location}, ${eventDetail.cardImageId} ${(eventDetail.mine) ? '(mine)' : ''}`);
+						moveCard(eventDetail);
+						break;
+					case 'flip':
+						// If there are multiple flips cached from the last play, grab them all to play simultaneously
+						debugMode && console.log(`flip card: ${eventDetail.location}`);
+						flipCard(eventDetail.location);
+						updatePlayerStrengthValues(eventDetail.matchDetail);
+						while (nextEventType('flip')) {
+							nextEventDetail = gameEventQueue.shift();
+							debugMode && console.log(`flip card: ${nextEventDetail.location}`);
+							flipCard(nextEventDetail.location);
+							updatePlayerStrengthValues(nextEventDetail.matchDetail);
+						}
+						break;
+					case 'draw':
+						debugMode && console.log(`io: draw hand --> canvas.startRound()`);
+						// TODO: Add a way of acknowledging the previous round before starting the next one
+						startRound(eventDetail.cards);
+						break;
+					case 'stoplight':
+						debugMode && console.log(`stoplight: ${JSON.stringify(eventDetail.matchDetail.scoreboard)}`);
+						updateScores(eventDetail.matchDetail);
+						break;
+					case 'enable':
+						// debugMode && console.log(`enable hand: ${eventDetail.active}`);
+						updateActivePlayer(eventDetail.active);
+						break;
+					case 'end':
+						debugMode && console.log(`endMatch`);
+						endMatch(eventDetail.matchDetail);
+						break;
+					default:
+						console.warn(`Unknown event type: ${eventDetail.type}`);
+						break;
+				}
+				gameEvent();
+			}, ANIMATION_TIME);
+		}
+	} else {
+		if (gameEventQueue.length) {
+			animationTimeout = setTimeout(() => {
+				gameEvent();
+			}, ANIMATION_TIME);
+		} else {
+			window.clearTimeout(animationTimeout);
+		}
+	}
+}
+
+function generateReplayFromLog (matchDetail) {
+	log = matchDetail.log;
+
+	playerRoundStrength = 5;
+	opponentRoundStrength = 5;
+
+	for (let i = 0; i < log.length; i++) {
+		const logBits = log[i].split(':');
+		// Log Format: {player color}:{event type}:{location}:{card index?}:{card id?}
+		// If the log entry begins with `red` or `blue`, it is an event that we need to queue up
+		if (logBits[0].includes('blue') || logBits[0].includes('red')) {
+			switch (logBits[1]) {
+				case 'play':
+					gameEventQueue.push({type: 'move', location: logBits[2], cardIndexInHand: logBits[3],  color: logBits[0], cardImageId: logBits[4], spectator: (logBits[0].includes(playerColor)) ? true : false});
+					break;
+				case 'capture':
+					// TODO: Either add the update score to the log, or always calculate it
+					if (logBits[0].includes('blue')) { // When spectating, assume the player is blue
+						playerRoundStrength++;
+						opponentRoundStrength--;
+					} else {
+						playerRoundStrength--;
+						opponentRoundStrength++;
+					}
+					gameEventQueue.push({type: 'flip', location: logBits[2], matchDetail: { roundStrength: {red: opponentRoundStrength, blue: playerRoundStrength}}});
+					break;
+				default:
+					console.warn(`Unknown log entry format: ${log[i]}`);
+					break;
+			}
+		} else if (logBits[0].includes('Begin Round')) {
+			gameEventQueue.push({type: 'draw', cards: true});
+		}
+	}
+
+	// Get things rolling, because gameEvent() cannot trigger until both hands have been rendered
+	startRound(true);
+	// IF THE FIRST ONE IS THE DRAW EVENT, WE CAN SKIP IT
+	gameEvent();
+}
+
 function nextEventType (eventType) {
-	let nextEvent = cardEventQueue[0];
+	let nextEvent = gameEventQueue[0];
 	if (nextEvent && nextEvent.type === eventType) {
 		return true;
 	} else {
@@ -201,13 +291,26 @@ function updateActivePlayer (activePlayer) {
 	} else {
 		setTimeout(() => {
 			updateActivePlayer(activePlayer);
-		}, ANIMATION_TIME);
+		}, ANIMATION_TIME * 2);
+	}
+}
+
+function updateGameList(selector, list) {
+	let listEl = document.querySelector(selector);
+	listEl.innerHTML = '';
+
+	for (let i = 0; i < list.length; i++) {
+		let match = list[i];
+		let row = document.createElement("li");
+		let score =  (selector === '.game-list') ? `(${match.runningScore.blue} - ${match.runningScore.red})` : '';
+		row.innerHTML = `<a href='/${match.id}' title='Join this match${(selector === '.game-list') ? " as a spectator" : ""}'>${match.id} ${score}</a>`;
+		listEl.appendChild(row);
 	}
 }
 
 // Any time a card is flipped, the round score values have changed, so update the numbers
 function updatePlayerStrengthValues (matchDetail) {
-	debugMode && console.log(`updatePlayerStrengthValues: ${JSON.stringify(matchDetail.roundStrength)}`);
+	debugMode && console.log(`--> ${JSON.stringify(matchDetail.roundStrength)}`);
 	renderPlayerScore(matchDetail.roundStrength[playerColor]);
 	renderPlayerScore(matchDetail.roundStrength[opponentColor], true);
 }
@@ -236,17 +339,19 @@ function endMatch (matchDetail) {
 	setTimeout(() => {
 		enableCards(true);
 		// TODO: Use game status notifications, instead of alerts
-		if (playerColor === winnerColor) {
-			playSound(fanfare);
-			// alert(`You win! (${matchDetail.scoreboard[winnerColor]} - ${matchDetail.scoreboard[loserColor]})`);
-		} else if (playerColor === loserColor) {
-			playSound(loser);
-			// alert(`You lose. (${matchDetail.scoreboard[loserColor]} - ${matchDetail.scoreboard[winnerColor]})`);
+		if (!spectator) {
+			if (playerColor === winnerColor) {
+				playSound(fanfare);
+				// alert(`You win! (${matchDetail.scoreboard[winnerColor]} - ${matchDetail.scoreboard[loserColor]})`);
+			} else if (playerColor === loserColor) {
+				playSound(loser);
+				// alert(`You lose. (${matchDetail.scoreboard[loserColor]} - ${matchDetail.scoreboard[winnerColor]})`);
+			}
+			renderRematchBlock();
 		} else {
-			// alert(`${winnerColor} wins! (${matchDetail.scoreboard[winnerColor]} - ${matchDetail.scoreboard[loserColor]})`);
+			alert(`${winnerColor} wins! (${matchDetail.scoreboard[winnerColor]} - ${matchDetail.scoreboard[loserColor]})`);
 		}
-		renderRematchBlock();
-	}, ANIMATION_TIME);
+	}, ANIMATION_TIME * 2);
 
 	// canPlayCard = false;
 	// readyToEnd = false;
@@ -273,6 +378,7 @@ function endMatch (matchDetail) {
 	// matchEndReason = undefined;
 }
 
+// TODO: DELETE THESE, ONCE GAME STATE IS STABLE
 function exitMatch () {
 	if (debugMode) console.log("%s(%s)", arguments.callee.name, Array.prototype.slice.call(arguments).sort());
 	playerRoundStrength = 0;

--- a/server.js
+++ b/server.js
@@ -41,9 +41,21 @@ app.get("/", (req, res) => {
 	// Will serve static pages, no need to handle requests
 });
 
-// If any page not handled already handled (ie. doesn't exist)
+// User/spectator requests a specific match
+app.get( '^/:matchId([ACDEFGHJKLMNPRTUWXY3679]{4})', (req, res) => {
+	// console.log(`Connection request for match: ${req.params.matchId}`);
+	// Forward lowercase requests to uppercase routes
+	if (/[a-z]/.test(req.params.matchId)) {
+		res.redirect(301, `/${req.params.matchId.toUpperCase()}`);
+	} else {
+		res.sendFile('index.html', {root: './public'});
+	}
+});
+
+// 404 catch-all for routes not matched
 app.get("*", (req, res) => {
-	res.status(404).send("Error 404 - Page not found");
+	// TODO: Just send them back to the lobby, and show a note that the match could not be found
+	res.status(404).send("Error 404 - Game not found");
 });
 
 // Start http server


### PR DESCRIPTION
Allow opponents and spectators to join by match IDs, with route validation and auto-capitalization.
Allow players to play against the computer.
On spectator connection, replay entire match up to that point from the match log.
Reformat match log entries to be easier to parse on the client for replays.
Rename cardEventQueue --> gameEventQueue.
Add initial lobby functionality, with automatically-updating lists of available games to watch and join.
Have AI provide card list, instead of importing multiple places.
Improve AI algorithm.
Various renamings, due to expanding functionality.

![lobbies](https://user-images.githubusercontent.com/2700098/82739353-38642400-9cfc-11ea-91eb-50dc466af033.png)
